### PR TITLE
Fixed img shrink/expanded issue

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -61,12 +61,14 @@ img {
   max-width: 60%;
   margin-top: 92px;
   margin-bottom: 92px;
+  object-fit: contain;
 }
 
 .divider {
   width: 40%;
   margin-top: 60px;
   margin-bottom: 60px;
+  object-fit: contain;
 }
 
 .agenda {


### PR DESCRIPTION
Quickly fixed image shrink issue only in Safari. I Ignored size due to along with the logic of framework (we can double-check & fix later probably with media query)